### PR TITLE
Improve site layout with shared header

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -70,3 +70,23 @@ tr:nth-child(even) {
     font-size: 16px;
     cursor: pointer;
 }
+.navbar {
+    background-color: #2b6cb0;
+    padding: 10px 20px;
+    color: #fff;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.navbar h1 {
+    font-size: 1.5em;
+    margin: 0;
+}
+.nav-links a {
+    color: #fff;
+    margin-left: 15px;
+    text-decoration: none;
+}
+.nav-links a:hover {
+    text-decoration: underline;
+}

--- a/src/main/resources/templates/contracts/detail.html
+++ b/src/main/resources/templates/contracts/detail.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Chi Tiết Hợp Đồng</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
     <style>
         body {
             background-color: #f4f4f4;
@@ -55,6 +56,7 @@
     </style>
 </head>
 <body>
+    <div th:replace="fragments/header :: header"></div>
     <div class="container">
         <h2>Chi Tiết Hợp Đồng</h2>
         <table class="info-table">

--- a/src/main/resources/templates/contracts/form.html
+++ b/src/main/resources/templates/contracts/form.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title th:text="${contract.id} ? 'Sửa Hợp Đồng' : 'Thêm Hợp Đồng'">Thêm Hợp Đồng</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
     <style>
         .container {
             max-width: 600px;
@@ -44,6 +45,7 @@
     </style>
 </head>
 <body>
+    <div th:replace="fragments/header :: header"></div>
     <div class="container">
         <h2 th:text="${contract.id} ? 'Sửa Hợp Đồng' : 'Thêm Hợp Đồng'"></h2>
         <form th:action="${contract.id} ? @{/contracts/{id}(id=${contract.id})} : @{/contracts}" th:object="${contract}" method="post">

--- a/src/main/resources/templates/contracts/list.html
+++ b/src/main/resources/templates/contracts/list.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" th:href="@{/css/style.css}">
 </head>
 <body>
+    <div th:replace="fragments/header :: header"></div>
     <div class="container">
         <h2>Danh Sách Hợp Đồng</h2>
         <div class="search-container">

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Dashboard Quản Lý Kí Túc Xá</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" th:href="@{/css/style.css}">
     <style>
         * {
             margin: 0;
@@ -14,42 +15,6 @@
         body {
             background: linear-gradient(135deg, #f0f4f8, #e6e9ef);
             color: #2d3748;
-        }
-        .nav-bar {
-            background: #ffffff;
-            padding: 15px 30px;
-            box-shadow: 0 2px 5px rgba(0,0,0,0.1);
-            position: fixed;
-            top: 0;
-            width: 100%;
-            z-index: 1000;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-        .nav-bar h1 {
-            font-size: 1.7em;
-            color: #2b6cb0;
-            margin: 0;
-            font-weight: 700;
-        }
-        .nav-links {
-            display: flex;
-            gap: 15px;
-        }
-        .nav-links a {
-            text-decoration: none;
-            color: #ffffff;
-            background-color: #38a169;
-            padding: 8px 16px;
-            border-radius: 20px;
-            font-size: 0.9em;
-            font-weight: 400;
-            transition: background-color 0.3s, transform 0.2s;
-        }
-        .nav-links a:hover {
-            background-color: #2f855a;
-            transform: translateY(-2px);
         }
         /* Nút giới thiệu nổi bật */
         #aboutPhenikaaBtn {
@@ -132,16 +97,6 @@
             to { opacity: 1; transform: translateY(0); }
         }
         @media (max-width: 768px) {
-            .nav-bar {
-                flex-direction: column;
-                gap: 15px;
-                padding: 20px;
-            }
-            .nav-links {
-                flex-wrap: wrap;
-                justify-content: center;
-                gap: 10px;
-            }
             .hero h2 {
                 font-size: 1.9em;
             }
@@ -208,16 +163,7 @@
     </style>
 </head>
 <body>
-    <div class="nav-bar">
-        <h1>Quản Lý Kí Túc Xá PHENIKAA UNI</h1>
-        <div class="nav-links">
-            <a th:href="@{/students}">Sinh Viên</a>
-            <a th:href="@{/rooms}">Phòng</a>
-            <a th:href="@{/contracts}">Hợp Đồng</a>
-            <a th:href="@{/fees}">Phí</a>
-            <a href="javascript:void(0)" id="aboutPhenikaaBtn">Giới thiệu</a>
-        </div>
-    </div>
+    <div th:replace="fragments/header :: header"></div>
     <div class="hero">
         <h2>Dashboard</h2>
         <p>Quản lý thông tin kí túc xá một cách dễ dàng và hiệu quả</p>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -2,8 +2,10 @@
 <html>
 <head>
     <title>Lỗi</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
 </head>
 <body>
+    <div th:replace="fragments/header :: header"></div>
     <h1>Có lỗi xảy ra</h1>
     <p th:text="${errorMessage}"></p>
     <a href="/students">Quay lại danh sách</a>

--- a/src/main/resources/templates/fees/detail.html
+++ b/src/main/resources/templates/fees/detail.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Chi Tiết Phí</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
     <style>
         body {
             background-color: #f4f4f4;
@@ -55,6 +56,7 @@
     </style>
 </head>
 <body>
+    <div th:replace="fragments/header :: header"></div>
     <div class="container">
         <h2>Chi Tiết Phí</h2>
         <table class="info-table">

--- a/src/main/resources/templates/fees/form.html
+++ b/src/main/resources/templates/fees/form.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title th:text="${fee.id} ? 'Sửa Phí' : 'Thêm Phí'">Thêm Phí</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
     <style>
         .container {
             max-width: 600px;
@@ -44,6 +45,7 @@
     </style>
 </head>
 <body>
+    <div th:replace="fragments/header :: header"></div>
     <div class="container">
         <h2 th:text="${fee.id} ? 'Sửa Phí' : 'Thêm Phí'"></h2>
         <form th:action="${fee.id} ? @{/fees/{id}(id=${fee.id})} : @{/fees}" th:object="${fee}" method="post">

--- a/src/main/resources/templates/fees/list.html
+++ b/src/main/resources/templates/fees/list.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" th:href="@{/css/style.css}">
 </head>
 <body>
+    <div th:replace="fragments/header :: header"></div>
     <div class="container">
         <h2>Danh Sách Phí</h2>
         <div class="search-container">

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,0 +1,13 @@
+<div th:fragment="header">
+    <header class="navbar">
+        <h1>Quản Lý KTX</h1>
+        <nav class="nav-links">
+            <a th:href="@{/dashboard}">Dashboard</a>
+            <a th:href="@{/students}">Sinh Viên</a>
+            <a th:href="@{/rooms}">Phòng</a>
+            <a th:href="@{/contracts}">Hợp Đồng</a>
+            <a th:href="@{/fees}">Phí</a>
+            <a href="javascript:void(0)" id="aboutPhenikaaBtn">Giới thiệu</a>
+        </nav>
+    </header>
+</div>

--- a/src/main/resources/templates/rooms/detail.html
+++ b/src/main/resources/templates/rooms/detail.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Chi Tiết Phòng</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
     <style>
         body {
             background-color: #f4f4f4;
@@ -79,6 +80,7 @@
     </style>
 </head>
 <body>
+    <div th:replace="fragments/header :: header"></div>
     <div class="container">
         <h2>Chi Tiết Phòng</h2>
         <table class="info-table">

--- a/src/main/resources/templates/rooms/form.html
+++ b/src/main/resources/templates/rooms/form.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title th:text="${room.id} ? 'Sửa Phòng' : 'Thêm Phòng'">Thêm Phòng</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
     <style>
         body {
             background: #f5f6fa;
@@ -95,6 +96,7 @@
     </script>
 </head>
 <body>
+    <div th:replace="fragments/header :: header"></div>
     <div class="container">
         <h2 th:text="${room.id} ? 'Sửa Phòng' : 'Thêm Phòng'"></h2>
         <form th:action="${room.id} ? @{/rooms/{id}(id=${room.id})} : @{/rooms}" th:object="${room}" method="post">

--- a/src/main/resources/templates/rooms/list.html
+++ b/src/main/resources/templates/rooms/list.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" th:href="@{/css/style.css}">
 </head>
 <body>
+    <div th:replace="fragments/header :: header"></div>
     <div class="container">
         <h2>Danh Sách Phòng</h2>
         <div class="search-container">

--- a/src/main/resources/templates/students/detail.html
+++ b/src/main/resources/templates/students/detail.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Chi Tiết Sinh Viên</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -42,6 +43,7 @@
     </style>
 </head>
 <body>
+    <div th:replace="fragments/header :: header"></div>
     <div class="container">
         <h2>Chi Tiết Sinh Viên</h2>
         <div class="detail">

--- a/src/main/resources/templates/students/form.html
+++ b/src/main/resources/templates/students/form.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title th:text="${student.id} ? 'Sửa Sinh Viên' : 'Thêm Sinh Viên'">Form</title>
+    <link rel="stylesheet" th:href="@{/css/style.css}">
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -87,6 +88,7 @@
     </style>
 </head>
 <body>
+    <div th:replace="fragments/header :: header"></div>
     <div class="container">
         <h2 th:text="${student.id} ? 'Sửa Sinh Viên' : 'Thêm Sinh Viên'"></h2>
         <form th:action="${student.id} ? @{/students/{id}(id=${student.id})} : @{/students}" th:object="${student}" method="post">

--- a/src/main/resources/templates/students/list.html
+++ b/src/main/resources/templates/students/list.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" th:href="@{/css/style.css}">
 </head>
 <body>
+    <div th:replace="fragments/header :: header"></div>
     <div class="container">
         <h2>Danh Sách Sinh Viên</h2>
         <div class="search-container">


### PR DESCRIPTION
## Summary
- add a reusable navigation header fragment
- update CSS with navbar styles
- include shared header across templates

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6854e6edd96c832a9a4061f1face029b