### PR TITLE
Improve search to match full names

### DIFF
--- a/src/main/java/com/example/dorm/repository/ContractRepository.java
+++ b/src/main/java/com/example/dorm/repository/ContractRepository.java
@@ -12,6 +12,17 @@ public interface ContractRepository extends JpaRepository<Contract, Long> {
     Page<Contract> findByStudent_CodeContainingIgnoreCaseOrStudent_NameContainingIgnoreCaseOrRoom_NumberContainingIgnoreCaseOrStatusContainingIgnoreCase(
             String code, String studentName, String roomNumber, String status, Pageable pageable);
 
+    @org.springframework.data.jpa.repository.Query("""
+            SELECT c FROM Contract c
+            WHERE lower(c.student.code) LIKE lower(concat('%', :search, '%'))
+               OR lower(c.room.number) LIKE lower(concat('%', :search, '%'))
+               OR lower(c.status) LIKE lower(concat('%', :search, '%'))
+               OR lower(c.student.name) = lower(:search)
+               OR lower(c.student.name) LIKE lower(concat(:search, ' %'))
+               OR lower(c.student.name) LIKE lower(concat('% ', :search))
+            """)
+    Page<Contract> searchByStudentWordOrCodeOrRoomOrStatus(@org.springframework.data.repository.query.Param("search") String search, Pageable pageable);
+
     java.util.List<Contract> findByRoom_Id(Long roomId);
 
     long countByRoom_Id(Long roomId);

--- a/src/main/java/com/example/dorm/repository/FeeRepository.java
+++ b/src/main/java/com/example/dorm/repository/FeeRepository.java
@@ -16,4 +16,25 @@ public interface FeeRepository extends JpaRepository<Fee, Long> {
 
     Page<Fee> findByTypeOrContract_Student_CodeContainingIgnoreCaseOrContract_Student_NameContainingIgnoreCase(
             FeeType type, String code, String name, Pageable pageable);
+
+    @org.springframework.data.jpa.repository.Query("""
+            SELECT f FROM Fee f
+            WHERE lower(f.contract.student.code) LIKE lower(concat('%', :search, '%'))
+               OR lower(f.contract.student.name) = lower(:search)
+               OR lower(f.contract.student.name) LIKE lower(concat(:search, ' %'))
+               OR lower(f.contract.student.name) LIKE lower(concat('% ', :search))
+            """)
+    Page<Fee> searchByContractStudentWord(@org.springframework.data.repository.query.Param("search") String search, Pageable pageable);
+
+    @org.springframework.data.jpa.repository.Query("""
+            SELECT f FROM Fee f
+            WHERE f.type = :type
+               OR lower(f.contract.student.code) LIKE lower(concat('%', :search, '%'))
+               OR lower(f.contract.student.name) = lower(:search)
+               OR lower(f.contract.student.name) LIKE lower(concat(:search, ' %'))
+               OR lower(f.contract.student.name) LIKE lower(concat('% ', :search))
+            """)
+    Page<Fee> searchByTypeOrContractStudentWord(@org.springframework.data.repository.query.Param("type") FeeType type,
+                                                @org.springframework.data.repository.query.Param("search") String search,
+                                                Pageable pageable);
 }

--- a/src/main/java/com/example/dorm/service/ContractService.java
+++ b/src/main/java/com/example/dorm/service/ContractService.java
@@ -98,7 +98,6 @@ public class ContractService {
             return contractRepository.findAll(pageable);
         }
         return contractRepository
-                .findByStudent_CodeContainingIgnoreCaseOrStudent_NameContainingIgnoreCaseOrRoom_NumberContainingIgnoreCaseOrStatusContainingIgnoreCase(
-                        search, search, search, search, pageable);
+                .searchByStudentWordOrCodeOrRoomOrStatus(search, pageable);
     }
 }

--- a/src/main/java/com/example/dorm/service/FeeService.java
+++ b/src/main/java/com/example/dorm/service/FeeService.java
@@ -58,11 +58,9 @@ public class FeeService {
         }
         if (type != null) {
             return feeRepository
-                    .findByTypeOrContract_Student_CodeContainingIgnoreCaseOrContract_Student_NameContainingIgnoreCase(
-                            type, search, search, pageable);
+                    .searchByTypeOrContractStudentWord(type, search, pageable);
         }
         return feeRepository
-                .findByContract_Student_CodeContainingIgnoreCaseOrContract_Student_NameContainingIgnoreCase(
-                        search, search, pageable);
+                .searchByContractStudentWord(search, pageable);
     }
 }

--- a/src/test/java/com/example/dorm/service/ContractServiceTest.java
+++ b/src/test/java/com/example/dorm/service/ContractServiceTest.java
@@ -69,4 +69,15 @@ class ContractServiceTest {
         update.setStudent(new Student());
         assertThrows(IllegalStateException.class, () -> contractService.updateContract(10L, update));
     }
+
+    @Test
+    void searchContractsUsesCustomQuery() {
+        org.springframework.data.domain.Page<Contract> page =
+                new org.springframework.data.domain.PageImpl<>(java.util.Collections.emptyList());
+        when(contractRepository.searchByStudentWordOrCodeOrRoomOrStatus(eq("An"), any(org.springframework.data.domain.Pageable.class)))
+                .thenReturn(page);
+        var result = contractService.searchContracts("An", org.springframework.data.domain.Pageable.unpaged());
+        assertSame(page, result);
+        verify(contractRepository).searchByStudentWordOrCodeOrRoomOrStatus(eq("An"), any(org.springframework.data.domain.Pageable.class));
+    }
 }

--- a/src/test/java/com/example/dorm/service/FeeServiceTest.java
+++ b/src/test/java/com/example/dorm/service/FeeServiceTest.java
@@ -37,4 +37,21 @@ class FeeServiceTest {
         assertNotNull(result);
         verify(feeRepository).save(existing);
     }
+
+    @Test
+    void searchFeesUsesCustomQueries() {
+        org.springframework.data.domain.Page<Fee> page =
+                new org.springframework.data.domain.PageImpl<>(java.util.Collections.emptyList());
+        when(feeRepository.searchByContractStudentWord(eq("An"), any(org.springframework.data.domain.Pageable.class)))
+                .thenReturn(page);
+        var result = feeService.searchFees("An", org.springframework.data.domain.Pageable.unpaged());
+        assertSame(page, result);
+        verify(feeRepository).searchByContractStudentWord(eq("An"), any(org.springframework.data.domain.Pageable.class));
+
+        when(feeRepository.searchByTypeOrContractStudentWord(eq(com.example.dorm.model.FeeType.CLEANING), eq("CLEANING"), any(org.springframework.data.domain.Pageable.class)))
+                .thenReturn(page);
+        result = feeService.searchFees("CLEANING", org.springframework.data.domain.Pageable.unpaged());
+        assertSame(page, result);
+        verify(feeRepository).searchByTypeOrContractStudentWord(eq(com.example.dorm.model.FeeType.CLEANING), eq("CLEANING"), any(org.springframework.data.domain.Pageable.class));
+    }
 }


### PR DESCRIPTION
## Summary
- refine contract and fee queries to match full student name words
- update services to use new search queries
- add unit tests for contract and fee search logic

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6857d63370e0832aa8f63625c5ab1f3c