### PR TITLE
Refactor tests to use TestConfiguration mocks

### DIFF
--- a/src/test/java/com/example/dorm/TestMockConfig.java
+++ b/src/test/java/com/example/dorm/TestMockConfig.java
@@ -1,0 +1,29 @@
+package com.example.dorm;
+
+import com.example.dorm.service.*;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestMockConfig {
+    @Bean
+    public ContractService contractService() {
+        return Mockito.mock(ContractService.class);
+    }
+
+    @Bean
+    public StudentService studentService() {
+        return Mockito.mock(StudentService.class);
+    }
+
+    @Bean
+    public RoomService roomService() {
+        return Mockito.mock(RoomService.class);
+    }
+
+    @Bean
+    public FeeService feeService() {
+        return Mockito.mock(FeeService.class);
+    }
+}

--- a/src/test/java/com/example/dorm/controller/ContractControllerTest.java
+++ b/src/test/java/com/example/dorm/controller/ContractControllerTest.java
@@ -8,8 +8,8 @@ import com.example.dorm.service.StudentService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import com.example.dorm.TestMockConfig;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -26,17 +26,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * Tests for {@link ContractController}.
  */
 @WebMvcTest(ContractController.class)
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, TestMockConfig.class})
 class ContractControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @Autowired
     private ContractService contractService;
-    @MockBean
+    @Autowired
     private StudentService studentService;
-    @MockBean
+    @Autowired
     private RoomService roomService;
 
     @Test
@@ -46,6 +46,7 @@ class ContractControllerTest {
 
         mockMvc.perform(get("/contracts"))
                 .andExpect(status().isOk())
-                .andExpect(view().name("contracts/list"));
+                .andExpect(view().name("contracts/list"))
+                .andExpect(model().attributeExists("contractsPage"));
     }
 }

--- a/src/test/java/com/example/dorm/controller/FeeControllerTest.java
+++ b/src/test/java/com/example/dorm/controller/FeeControllerTest.java
@@ -7,8 +7,8 @@ import com.example.dorm.service.FeeService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import com.example.dorm.TestMockConfig;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -25,15 +25,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * Tests for {@link FeeController}.
  */
 @WebMvcTest(FeeController.class)
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, TestMockConfig.class})
 class FeeControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @Autowired
     private FeeService feeService;
-    @MockBean
+    @Autowired
     private ContractService contractService;
 
     @Test
@@ -43,6 +43,7 @@ class FeeControllerTest {
 
         mockMvc.perform(get("/fees"))
                 .andExpect(status().isOk())
-                .andExpect(view().name("fees/list"));
+                .andExpect(view().name("fees/list"))
+                .andExpect(model().attributeExists("feesPage"));
     }
 }

--- a/src/test/java/com/example/dorm/controller/RoomControllerTest.java
+++ b/src/test/java/com/example/dorm/controller/RoomControllerTest.java
@@ -5,8 +5,8 @@ import com.example.dorm.service.RoomService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import com.example.dorm.TestMockConfig;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -23,13 +23,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * Tests for {@link RoomController}.
  */
 @WebMvcTest(RoomController.class)
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, TestMockConfig.class})
 class RoomControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @Autowired
     private RoomService roomService;
 
     @Test
@@ -39,6 +39,7 @@ class RoomControllerTest {
 
         mockMvc.perform(get("/rooms"))
                 .andExpect(status().isOk())
-                .andExpect(view().name("rooms/list"));
+                .andExpect(view().name("rooms/list"))
+                .andExpect(model().attributeExists("roomsPage"));
     }
 }

--- a/src/test/java/com/example/dorm/controller/StudentControllerTest.java
+++ b/src/test/java/com/example/dorm/controller/StudentControllerTest.java
@@ -6,11 +6,10 @@ import com.example.dorm.service.ContractService;
 import com.example.dorm.service.RoomService;
 import com.example.dorm.service.StudentService;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import com.example.dorm.TestMockConfig;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -26,17 +25,17 @@ import static org.mockito.Mockito.*;
  * Controller tests for {@link StudentController}.
  */
 @WebMvcTest(StudentController.class)
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, TestMockConfig.class})
 class StudentControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @Autowired
     private StudentService studentService;
-    @MockBean
+    @Autowired
     private RoomService roomService;
-    @MockBean
+    @Autowired
     private ContractService contractService;
 
     @Test
@@ -46,7 +45,8 @@ class StudentControllerTest {
 
         mockMvc.perform(get("/students"))
                 .andExpect(status().isOk())
-                .andExpect(view().name("students/list"));
+                .andExpect(view().name("students/list"))
+                .andExpect(model().attributeExists("studentsPage"));
 
         verify(studentService).searchStudents(anyString(), any(Pageable.class));
     }


### PR DESCRIPTION
## Summary
- add `TestMockConfig` providing mock service beans using `@TestConfiguration`
- replace deprecated `@MockBean` usage with injected mocks via `@Import(TestMockConfig)`
- assert expected model attributes in controller tests

## Testing
- `mvn -v` *(fails: command not found)*
- `bash mvnw.cmd -q test` *(fails: syntax error in Windows script)*

------
https://chatgpt.com/codex/tasks/task_b_685a15a28eb8832a9af050ffe188730a